### PR TITLE
Refactor permission check to use an allowlist, rather than inspect teams/org via Github API

### DIFF
--- a/.github/workflows/dev_harness.yaml
+++ b/.github/workflows/dev_harness.yaml
@@ -25,7 +25,8 @@ jobs:
       - id: run-bridger
         uses: mozmeao/asana-github-bridge/issue-handler@main
         with:
-          only-react-to: repo-org
+          ONLY_REACT_TO: specified-users
+          ACTOR_ALLOWLIST: stevejalim,pmac,robhudson,enavajas
           ASANA_PAT: ${{ secrets.ASANA_PAT }}
           ASANA_PROJECT: ${{ secrets.ASANA_PROJECT }}
           REPO_TOKEN: ${{ secrets.ASANA_GITHUB_BRIDGE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Loose roadmap:
 1. Set up your repo's secrets to make `ASANA_PAT` and `ASANA_PROJECT` available - both of these you get from the Asana side. Ideally, the PAT should be an Asana [service account](https://asana.com/guide/help/premium/service-accounts) token. You can get the Project ID from the URL of the project.
 
 2. Ideally using a service account, create a Github Personal Access Token (e.g. called `ASANA_GITHUB_BRIDGE_TOKEN`) with these permissions:
-    * `read: org` - we need see organization membership and team membership, unless you're allowing `only-react-to: all` in the action (see below)
-    * `repo: public_repo` - to be able to comment on the original Issue _for a public repository_. If this is not present, the commenting with the Asana link will not happen, but the copy to Asana will. If the repo is private, you will likely need to add to the scope to be able to support comments. The output of the GH Action will show you if the token has sufficient scope.
+    * `repo: public_repo` - to be able to comment on the original Issue _for a public repository_. If this is not present, the commenting with the Asana link will not happen, but the copy to Asana will. If the repo is private, you will likely need to add to the full `repo` scope to be able to support comments. The output of the GH Action will show you if the token has sufficient scope.
 
     If you are using SSO remember to authorize that token for access.
 
@@ -54,10 +53,11 @@ jobs:
     name: "Trigger following GH Issue creation"
     uses: mozmeao/asana-github-bridge/issue-handler@v1.1
     with:
-      only-react-to: repo-org   # optional - see issue_handler.yaml
+      ONLY_REACT_TO: specified-users   # optional - see issue_handler.yaml
+      ACTOR_ALLOWLIST: usernameA,userB,userC
       ASANA_PAT: ${{ secrets.ASANA_PAT }}
       ASANA_PROJECT: ${{ secrets.ASANA_PROJECT }}
-      REPO_TOKEN: ${{ secrets.ASANA_GITHUB_BRIDGE_TOKEN }}  # or secrets.GITHUB_TOKEN - see point 2 above
+      REPO_TOKEN: ${{ secrets.ASANA_GITHUB_BRIDGE_TOKEN }}  # see point 2 above
       TAG: v1.1  # version of the bridge to use - see the repo for tags
 
 ```
@@ -79,10 +79,11 @@ jobs:
     name: "Trigger after specific GH label was added"
     uses: mozmeao/asana-github-bridge/issue-handler@v1.1
     with:
-      only-react-to: repo-org   # optional - see issue_handler.yaml
+      ONLY_REACT_TO: specified-users   # optional - see issue_handler.yaml
+      ACTOR_ALLOWLIST: usernameA,userB,userC
       ASANA_PAT: ${{ secrets.ASANA_PAT }}
       ASANA_PROJECT: ${{ secrets.ASANA_PROJECT }}
-      REPO_TOKEN: ${{ secrets.ASANA_GITHUB_BRIDGE_TOKEN }}  # or secrets.GITHUB_TOKEN - see point 2 above
+      REPO_TOKEN: ${{ secrets.ASANA_GITHUB_BRIDGE_TOKEN }}  # see point 2 above
       TAG: v1.1  # version of the bridge to use - see the repo for tags
 
 ```

--- a/issue-handler/action.yaml
+++ b/issue-handler/action.yaml
@@ -7,14 +7,18 @@ name: "Github-Asana bridge"
 description: "Action to manage an Asana Task based on activity in Github"
 
 inputs:
-  only-react-to:
+  ONLY_REACT_TO:
     description: >
-      What user set to react to. One of: `repo-team | repo-org | all`
-      where `all` is anyone with access to raise an Issue, `repo-team`
-      has team-level access to the caller repo and `repo-org` is someone
-      with org-level _membership_ for the org the caller repo is in
+      What user set to react to. One of: `specified-users | all`
+      where `all` is anyone with access to raise an Issue, while
+      `specified-users` is an allowlist of usernames, passed as ACTOR_ALLOWLIST
     required: false
     default: repo-org
+  ACTOR_ALLOWLIST:
+    description: >
+      Comma-separated string of login names/usernames who may trigger
+      mirroring to Asana - see ONLY_REACT_TO
+    required: false
   ASANA_PROJECT:
     description: The Asana project two which you are bridging.
     required: true
@@ -56,4 +60,5 @@ runs:
         ISSUE_URL: ${{ github.event.issue.html_url }}
         REPO: ${{ github.repository }}
         REPO_TOKEN: ${{ inputs.REPO_TOKEN }}
-        ONLY_REACT_TO: ${{ inputs.only-react-to }}
+        ONLY_REACT_TO: ${{ inputs.ONLY_REACT_TO }}
+        ACTOR_ALLOWLIST: ${{ inputs.ACTOR_ALLOWLIST }}


### PR DESCRIPTION
When moving this project to production, we encountered a situation where the limited scope of the a service account's token was a problem and blocked the use of this Action:

* Non-members of an org cannot probe org membership
* Service/non-human accounts may not be added to an org based on Mozilla's own rules

As such, this changeset pivots to use a more manual, but greatly simpler approach where we simply have an allowlist of Github usernames for the users whose actions are allowed to trigger the Github-Asana bridge. For an org like Mozilla, where we work in the open, these usernames are readily deriveable and so I'm not considering them secret, so they can be added into a GHA workflow that uses this action. (Disagreements welcome on this - speak up if you don't agree)